### PR TITLE
Initial Android Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem "noticed"
 # APNS integration for push notifications on iOS [https://github.com/ostinelli/apnotic]
 gem "apnotic"
 
+# Render markdown as HTML.
+gem "redcarpet"
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redcarpet (3.5.1)
     redis (4.6.0)
     regexp_parser (2.5.0)
     reline (0.3.1)
@@ -278,6 +279,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.3)
+  redcarpet
   redis (~> 4.0)
   sprockets-rails
   standard

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Creating, updating, or deleting blog posts requires you to be signed in.
 
 ## Installation
 
-To run the perform the following:
+To run the example, perform the following:
 
  * Clone the repo
  * run `bundle install`
@@ -21,7 +21,7 @@ To run the perform the following:
  * run rails db:migrate
  * run `bin/dev` 
    * This will install foreman the first time if you dont have it already installed. If this is the case you will need to run `bin/dev` again
- * Visit `localhost:3000` in your browser, app should be running
+ * Visit `localhost:3000` in your browser, app should be running  
 
 ## Path Configuration
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ The app is a blogging example with limited functionality. You can perform CRUD o
 
 Creating, updating, or deleting blog posts requires you to be signed in.
 
+## Installation
+
+To run the perform the following:
+
+ * Clone the repo
+ * run `bundle install`
+ * run `yarn`
+ * run rails db:create
+ * run rails db:migrate
+ * run `bin/dev` 
+   * This will install foreman the first time if you dont have it already installed. If this is the case you will need to run `bin/dev` again
+ * Visit `localhost:3000` in your browser, app should be running
+
 ## Path Configuration
 
 The `PathConfigurationsController` configures the settings and tabs for your app.

--- a/app/assets/images/icons/compose.svg
+++ b/app/assets/images/icons/compose.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M2 4v14h14v-6l2-2v10H0V2h10L8 4H2zm10.3-.3l4 4L8 16H4v-4l8.3-8.3zm1.4-1.4L16 0l4 4-2.3 2.3-4-4z"/></svg>

--- a/app/assets/images/icons/home.svg
+++ b/app/assets/images/icons/home.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M8 20H3V10H0L10 0l10 10h-3v10h-5v-6H8v6z"/></svg>

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -1,7 +1,7 @@
 module API
   module V1
     class AuthsController < ApplicationController
-      skip_before_action :authenticate_token!
+      skip_before_action :authenticate_token!, only: [:create]
 
       def create
         if (user = User.valid_credentials?(params[:email], params[:password]))

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,4 +1,15 @@
 class SiteController < ApplicationController
   def show
+    @readme = renderer.render(File.read(file))
+  end
+
+  private
+
+  def renderer
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+  end
+
+  def file
+    Rails.root.join("README.md")
   end
 end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,0 +1,4 @@
+class SiteController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/turbo/android/path_configurations_controller.rb
+++ b/app/controllers/turbo/android/path_configurations_controller.rb
@@ -1,0 +1,74 @@
+module Turbo
+  module Android
+    class PathConfigurationsController < ApplicationController
+      def show
+        render json: {
+          settings: {
+            # Tabs are serialized to a string. RE: https://github.com/hotwired/turbo-android/issues/209
+            tabs: [
+              {
+                title: "Home",
+                path: root_path,
+                image_url: svg_icon_path("home")
+              },
+              {
+                title: "Posts",
+                path: posts_path,
+                image_url: svg_icon_path("compose")
+              }
+            ].to_json
+          },
+          rules: [
+            {
+              patterns: [".*"],
+              properties: {
+                context: "default",
+                uri: "turbo://fragment/web",
+                fallback_uri: "turbo://fragment/web",
+                pull_to_refresh_enabled: true
+              }
+            },
+            {
+              patterns: ["^$", "^/$"],
+              properties: {
+                uri: "turbo://fragment/web/home",
+                presentation: "replace_root"
+              }
+            },
+            {
+              patterns: ["/new$", "/edit$"],
+              properties: {
+                context: "modal",
+                uri: "turbo://fragment/web/modal/sheet",
+                pull_to_refresh_enabled: false
+              }
+            },
+            {
+              patterns: ["/users/sign_in"],
+              properties: {
+                uri: "turbo://fragment/users/sign_in",
+                context: "modal"
+              }
+            },
+            # Needs a /api/v1/users_controller.rb for auth if you want native sign up
+            # {
+            #   patterns: ["/users/sign_up"],
+            #   properties: {
+            #     uri: "turbo://fragment/users/sign_up",
+            #     context: "modal"
+            #   }
+            # }
+          ]
+        }
+      end
+
+      private 
+
+        # Provide the name of the icon
+      def svg_icon_path(icon)
+        ActionController::Base.helpers.asset_path("icons/#{icon}.svg")
+      end
+
+    end
+  end
+end

--- a/app/controllers/turbo/android/path_configurations_controller.rb
+++ b/app/controllers/turbo/android/path_configurations_controller.rb
@@ -50,7 +50,7 @@ module Turbo
                 context: "modal"
               }
             },
-            # Needs a /api/v1/users_controller.rb for auth if you want native sign up
+            # TODO: Needs a /api/v1/users_controller.rb for registration to work
             # {
             #   patterns: ["/users/sign_up"],
             #   properties: {

--- a/app/controllers/turbo/android/path_configurations_controller.rb
+++ b/app/controllers/turbo/android/path_configurations_controller.rb
@@ -49,15 +49,7 @@ module Turbo
                 uri: "turbo://fragment/users/sign_in",
                 context: "modal"
               }
-            },
-            # TODO: Needs a /api/v1/users_controller.rb for registration to work
-            # {
-            #   patterns: ["/users/sign_up"],
-            #   properties: {
-            #     uri: "turbo://fragment/users/sign_up",
-            #     context: "modal"
-            #   }
-            # }
+            }
           ]
         }
       end

--- a/app/controllers/turbo/ios/path_configurations_controller.rb
+++ b/app/controllers/turbo/ios/path_configurations_controller.rb
@@ -22,14 +22,15 @@ module Turbo
                 presentation: "modal"
               }
             },
-            {
-              patterns: [
-                "/users/sign_up"
-              ],
-              properties: {
-                flow: "registration"
-              }
-            },
+            # Needs a /api/v1/users_controller.rb for auth if you want native sign up
+            # {
+            #   patterns: [
+            #     "/users/sign_up"
+            #   ],
+            #   properties: {
+            #     flow: "registration"
+            #   }
+            # },
             {
               patterns: [
                 "/users/sign_in"

--- a/app/controllers/turbo/ios/path_configurations_controller.rb
+++ b/app/controllers/turbo/ios/path_configurations_controller.rb
@@ -22,15 +22,6 @@ module Turbo
                 presentation: "modal"
               }
             },
-            # TODO: Needs a /api/v1/users_controller.rb for registration to work
-            # {
-            #   patterns: [
-            #     "/users/sign_up"
-            #   ],
-            #   properties: {
-            #     flow: "registration"
-            #   }
-            # },
             {
               patterns: [
                 "/users/sign_in"

--- a/app/controllers/turbo/ios/path_configurations_controller.rb
+++ b/app/controllers/turbo/ios/path_configurations_controller.rb
@@ -22,7 +22,7 @@ module Turbo
                 presentation: "modal"
               }
             },
-            # Needs a /api/v1/users_controller.rb for auth if you want native sign up
+            # TODO: Needs a /api/v1/users_controller.rb for registration to work
             # {
             #   patterns: [
             #     "/users/sign_up"

--- a/app/controllers/turbo/ios/path_configurations_controller.rb
+++ b/app/controllers/turbo/ios/path_configurations_controller.rb
@@ -7,8 +7,13 @@ module Turbo
             tabs: [
               {
                 title: "Home",
-                path: "/",
+                path: root_path,
                 ios_system_image_name: "house"
+              },
+              {
+                title: "Posts",
+                path: posts_path,
+                ios_system_image_name: "square.and.pencil"
               }
             ]
           },

--- a/app/javascript/src/turbo_native/bridge.js
+++ b/app/javascript/src/turbo_native/bridge.js
@@ -1,6 +1,10 @@
 class Bridge {
   static postMessage(name, data = {}) {
+    // iOS
     window.webkit?.messageHandlers?.nativeApp?.postMessage({name, ...data})
+
+    // Android
+    window.nativeApp?.postMessage(JSON.stringify({name, ...data}))
   }
 
   static get isTurboNativeApp() {

--- a/app/notifications/new_post_notification.rb
+++ b/app/notifications/new_post_notification.rb
@@ -9,7 +9,6 @@ class NewPostNotification < ApplicationNotification
   deliver_by :database
   deliver_by :ios, format: :ios_format, development: :development?
 
-
   param :post
 
   def message

--- a/app/notifications/new_post_notification.rb
+++ b/app/notifications/new_post_notification.rb
@@ -9,6 +9,7 @@ class NewPostNotification < ApplicationNotification
   deliver_by :database
   deliver_by :ios, format: :ios_format, development: :development?
 
+
   param :post
 
   def message

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,6 @@
 <div class="w-full">
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Posts</h1>
+    <h1 class="font-bold text-4xl text-gray-900">Posts</h1>
     <%= link_to "New post", new_post_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/app/views/site/show.html.erb
+++ b/app/views/site/show.html.erb
@@ -1,4 +1,5 @@
 <div class="w-full">
   <div class="min-w-full prose">
+    <%== @readme %>
   </div>
 </div>

--- a/app/views/site/show.html.erb
+++ b/app/views/site/show.html.erb
@@ -1,0 +1,4 @@
+<div class="w-full">
+  <div class="min-w-full prose">
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
 
+  resource :site
   resources :posts
 
   namespace :api, defaults: {format: :json} do
@@ -20,5 +21,5 @@ Rails.application.routes.draw do
   end
 
   # Defines the root path route ("/")
-  root "posts#index"
+  root "site#show"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
     namespace :ios do
       resource :path_configuration, only: :show
     end
+    namespace :android do
+      resource :path_configuration, only: :show
+    end
   end
 
   # Defines the root path route ("/")

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.0.1",
     "@hotwired/turbo-rails": "^7.1.3",
+    "@tailwindcss/typography": "^0.5.2",
     "autoprefixer": "^10.4.7",
     "esbuild": "^0.14.43",
     "postcss": "^8.4.14",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,5 +4,8 @@ module.exports = {
     './app/helpers/**/*.rb',
     './app/assets/stylesheets/**/*.css',
     './app/javascript/**/*.js'
+  ],
+  plugins: [
+    require('@tailwindcss/typography')
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,15 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.3.tgz#71f08e958883af64f6a20489318b5e95d2c6dc5b"
   integrity sha512-Iefl21FZD+ck1di6xSHMYzSzRiNJTHV4NrAzCfDfqc/wPz4xncrP8f2/fJ+2jzwKIaDn76UVMsALh7R5OzsF8Q==
 
+"@tailwindcss/typography@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.2.tgz#24b069dab24d7a2467d01aca0dd432cb4b29f0ee"
+  integrity sha512-coq8DBABRPFcVhVIk6IbKyyHUt7YTEC/C992tatFB+yEx5WGBQrCgsSFjxHUr8AWXphWckadVJbominEduYBqw==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+
 acorn-node@^1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
@@ -404,6 +413,21 @@ lilconfig@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.5.tgz#19e57fd06ccc3848fd1891655b5a447092225b25"
   integrity sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==
+
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 merge2@^1.3.0:
   version "1.4.1"


### PR DESCRIPTION
Adding Android support
    
New path configuration file for Android.
SVG Files since Android doesnt ship with any.
Enable authentication on destroy action of auths controller.
Removed iOS native registration in path configuration in as we do not have a user controller in the API. RE: #15 

Still to do (in another PR: Notifications)

Supports #13 